### PR TITLE
adds /api as prefix for rest views

### DIFF
--- a/modules/wkhub_person/config/install/views.view.employee_listing.yml
+++ b/modules/wkhub_person/config/install/views.view.employee_listing.yml
@@ -538,7 +538,7 @@ display:
     display_options:
       field_langcode: '***LANGUAGE_language_content***'
       field_langcode_add_to_query: null
-      path: employees
+      path: api/employees
       pager:
         type: none
         options:
@@ -605,7 +605,7 @@ display:
         arguments: false
         style: true
         row: true
-      path: employees/%
+      path: api/employees/%
       pager:
         type: some
         options:


### PR DESCRIPTION
This pull request adds `/api` as prefix for REST views. That make it easy to distinguish from other content on the WunderHub.