### PR TITLE
fix form display for job position and place of work field

### DIFF
--- a/modules/wkhub_person/config/install/core.entity_form_display.user.user.default.yml
+++ b/modules/wkhub_person/config/install/core.entity_form_display.user.user.default.yml
@@ -46,14 +46,22 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_person_office:
-    type: options_buttons
+    type: entity_reference_autocomplete
     weight: 4
-    settings: {  }
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      autocomplete_type: tags
+      placeholder: ''
     third_party_settings: {  }
   field_person_jobtitle:
-    type: options_buttons
+    type: entity_reference_autocomplete
     weight: 5
-    settings: {  }
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      autocomplete_type: tags
+      placeholder: ''
     third_party_settings: {  }
   field_person_email:
     type: email_default

--- a/modules/wkhub_person/config/install/field.field.user.user.field_person_jobtitle.yml
+++ b/modules/wkhub_person/config/install/field.field.user.user.field_person_jobtitle.yml
@@ -23,6 +23,6 @@ settings:
       jobtitle: jobtitle
     sort:
       field: _none
-    auto_create: false
+    auto_create: true
 third_party_settings: {  }
 field_type: entity_reference

--- a/modules/wkhub_person/config/install/field.field.user.user.field_person_office.yml
+++ b/modules/wkhub_person/config/install/field.field.user.user.field_person_office.yml
@@ -23,6 +23,6 @@ settings:
       wk_office: wk_office
     sort:
       field: _none
-    auto_create: false
+    auto_create: true
 third_party_settings: {  }
 field_type: entity_reference


### PR DESCRIPTION
When you install the WunderHub it's not possible to create some testing data because no taxonomy terms are there on a fresh install. I would propose to use an autocomplete field which is enabled for entity creation so that new terms can be created through autocomplete field.