### PR TITLE
Add support for blogs from the WunderHub

### DIFF
--- a/config/install/bartik.settings.yml
+++ b/config/install/bartik.settings.yml
@@ -1,0 +1,14 @@
+features:
+  logo: true
+  name: true
+  slogan: true
+  node_user_picture: true
+  comment_user_picture: true
+  comment_user_verification: true
+  favicon: true
+logo:
+  use_default: true
+  path: ''
+favicon:
+  use_default: true
+  path: ''

--- a/config/install/block.block.bartik_help.yml
+++ b/config/install/block.block.bartik_help.yml
@@ -7,8 +7,8 @@ dependencies:
     - bartik
 id: bartik_help
 theme: bartik
-region: help
-weight: 0
+region: highlighted
+weight: -5
 provider: null
 plugin: help_block
 settings:

--- a/config/install/block.block.bartik_login.yml
+++ b/config/install/block.block.bartik_login.yml
@@ -8,7 +8,7 @@ dependencies:
 id: bartik_login
 theme: bartik
 region: '-1'
-weight: 0
+weight: -3
 provider: null
 plugin: user_login_block
 settings:

--- a/config/install/block.block.bartik_powered.yml
+++ b/config/install/block.block.bartik_powered.yml
@@ -8,7 +8,7 @@ dependencies:
 id: bartik_powered
 theme: bartik
 region: footer_fifth
-weight: -6
+weight: -5
 provider: null
 plugin: system_powered_by_block
 settings:

--- a/config/install/block.block.bartik_search.yml
+++ b/config/install/block.block.bartik_search.yml
@@ -8,7 +8,7 @@ dependencies:
 id: bartik_search
 theme: bartik
 region: '-1'
-weight: -1
+weight: -4
 provider: null
 plugin: search_form_block
 settings:

--- a/config/install/block.block.primaryadminactions.yml
+++ b/config/install/block.block.primaryadminactions.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  theme:
+    - seven
+id: primaryadminactions
+theme: seven
+region: pre_content
+weight: -2
+provider: null
+plugin: local_actions_block
+settings:
+  id: local_actions_block
+  label: 'Primary admin actions'
+  provider: core
+  label_display: '0'
+  cache:
+    max_age: 0
+visibility: {  }

--- a/config/install/block.block.seven_breadcrumbs.yml
+++ b/config/install/block.block.seven_breadcrumbs.yml
@@ -8,7 +8,7 @@ dependencies:
 id: seven_breadcrumbs
 theme: seven
 region: breadcrumb
-weight: 0
+weight: -2
 provider: null
 plugin: system_breadcrumb_block
 settings:

--- a/config/install/block.block.seven_content.yml
+++ b/config/install/block.block.seven_content.yml
@@ -8,7 +8,7 @@ dependencies:
 id: seven_content
 theme: seven
 region: content
-weight: 0
+weight: -1
 provider: null
 plugin: system_main_block
 settings:

--- a/config/install/block.block.seven_help.yml
+++ b/config/install/block.block.seven_help.yml
@@ -8,7 +8,7 @@ dependencies:
 id: seven_help
 theme: seven
 region: help
-weight: 0
+weight: -2
 provider: null
 plugin: help_block
 settings:

--- a/config/install/block.block.seven_login.yml
+++ b/config/install/block.block.seven_login.yml
@@ -8,7 +8,7 @@ dependencies:
 id: seven_login
 theme: seven
 region: content
-weight: 10
+weight: -2
 provider: null
 plugin: user_login_block
 settings:

--- a/config/install/block.block.tabs.yml
+++ b/config/install/block.block.tabs.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  theme:
+    - seven
+id: tabs
+theme: seven
+region: header
+weight: -5
+provider: null
+plugin: local_tasks_block
+settings:
+  id: local_tasks_block
+  label: Tabs
+  provider: core
+  label_display: '0'
+  cache:
+    max_age: 0
+  primary: true
+  secondary: true
+visibility: {  }

--- a/config/install/block.block.tabs_2.yml
+++ b/config/install/block.block.tabs_2.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  theme:
+    - bartik
+id: tabs_2
+theme: bartik
+region: content
+weight: -6
+provider: null
+plugin: local_tasks_block
+settings:
+  id: local_tasks_block
+  label: Tabs
+  provider: core
+  label_display: '0'
+  cache:
+    max_age: 0
+  primary: true
+  secondary: true
+visibility: {  }

--- a/config/install/color.theme.bartik.yml
+++ b/config/install/color.theme.bartik.yml
@@ -8,9 +8,9 @@ palette:
   titleslogan: '#fffeff'
   text: '#3b3b3b'
   link: '#e10075'
-logo: 'public://color/bartik-2e371f9a/logo.svg'
+logo: 'public://color/bartik-8949a3ec/logo.svg'
 stylesheets:
-  - 'public://color/bartik-2e371f9a/colors.css'
+  - 'public://color/bartik-8949a3ec/colors.css'
 files:
-  - 'public://color/bartik-2e371f9a/logo.svg'
-  - 'public://color/bartik-2e371f9a/colors.css'
+  - 'public://color/bartik-8949a3ec/logo.svg'
+  - 'public://color/bartik-8949a3ec/colors.css'

--- a/config/install/editor.editor.basic_html.yml
+++ b/config/install/editor.editor.basic_html.yml
@@ -1,4 +1,3 @@
-uuid: 6f8d67d9-f928-4dd6-a816-224a4e2daba6
 langcode: en
 status: true
 dependencies:

--- a/config/install/editor.editor.basic_html.yml
+++ b/config/install/editor.editor.basic_html.yml
@@ -1,3 +1,4 @@
+uuid: 6f8d67d9-f928-4dd6-a816-224a4e2daba6
 langcode: en
 status: true
 dependencies:
@@ -35,14 +36,15 @@ settings:
           name: Tools
           items:
             - Source
+            - Styles
   plugins:
     stylescombo:
-      styles: ''
+      styles: "h1|Heading 1\r\nh2|Heading 2\r\nh3|Heading 3\r\nh4|Heading 4\r\nh5|Heading 5\r\nh6|Heading 6"
 image_upload:
   status: true
   scheme: public
   directory: inline-images
   max_size: ''
   max_dimensions:
-    width: 0
-    height: 0
+    width: null
+    height: null

--- a/config/install/filter.format.basic_html.yml
+++ b/config/install/filter.format.basic_html.yml
@@ -1,3 +1,4 @@
+uuid: a7b3abd7-88a2-44a7-a300-c9e46df3c21f
 langcode: en
 status: true
 dependencies:
@@ -13,7 +14,7 @@ filters:
     status: true
     weight: -10
     settings:
-      allowed_html: '<a> <em> <strong> <cite> <blockquote> <code> <ul> <ol> <li> <dl> <dt> <dd> <h4> <h5> <h6> <p> <br> <span> <img>'
+      allowed_html: '<a> <em> <strong> <cite> <blockquote> <code> <ul> <ol> <li> <dl> <dt> <dd> <h4> <h5> <h6> <p> <br> <span> <img> <h1> <h2> <h3> <h4> <h5> <h6>'
       filter_html_help: false
       filter_html_nofollow: false
   filter_align:

--- a/config/install/filter.format.basic_html.yml
+++ b/config/install/filter.format.basic_html.yml
@@ -1,4 +1,3 @@
-uuid: a7b3abd7-88a2-44a7-a300-c9e46df3c21f
 langcode: en
 status: true
 dependencies:

--- a/modules/wkhub_blog/config/install/core.base_field_override.node.blog.promote.yml
+++ b/modules/wkhub_blog/config/install/core.base_field_override.node.blog.promote.yml
@@ -1,4 +1,3 @@
-uuid: f2f67f71-65aa-4beb-a905-5c0f3d686905
 langcode: en
 status: true
 dependencies:

--- a/modules/wkhub_blog/config/install/core.base_field_override.node.blog.promote.yml
+++ b/modules/wkhub_blog/config/install/core.base_field_override.node.blog.promote.yml
@@ -1,0 +1,22 @@
+uuid: f2f67f71-65aa-4beb-a905-5c0f3d686905
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.blog
+id: node.blog.promote
+field_name: promote
+entity_type: node
+bundle: blog
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/modules/wkhub_blog/config/install/core.entity_form_display.node.blog.default.yml
+++ b/modules/wkhub_blog/config/install/core.entity_form_display.node.blog.default.yml
@@ -1,0 +1,101 @@
+uuid: 6befcc31-8c95-48a3-8a05-5e38e4cd2561
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.blog.body
+    - field.field.node.blog.field_country
+    - field.field.node.blog.field_image
+    - field.field.node.blog.field_intro
+    - field.field.node.blog.field_kicker
+    - field.field.node.blog.field_tags
+    - node.type.blog
+  module:
+    - image
+    - path
+    - text
+id: node.blog.default
+targetEntityType: node
+bundle: blog
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 8
+    settings:
+      rows: 9
+      placeholder: ''
+      summary_rows: 5
+    third_party_settings: {  }
+  created:
+    type: datetime_timestamp
+    weight: 2
+    settings: {  }
+    third_party_settings: {  }
+  field_country:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+  field_image:
+    weight: 6
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
+  field_intro:
+    weight: 7
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+  field_kicker:
+    weight: 9
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+  field_tags:
+    weight: 11
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+  path:
+    type: path
+    weight: 5
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 3
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 4
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 1
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/modules/wkhub_blog/config/install/core.entity_form_display.node.blog.default.yml
+++ b/modules/wkhub_blog/config/install/core.entity_form_display.node.blog.default.yml
@@ -1,4 +1,3 @@
-uuid: 6befcc31-8c95-48a3-8a05-5e38e4cd2561
 langcode: en
 status: true
 dependencies:

--- a/modules/wkhub_blog/config/install/core.entity_view_display.node.blog.default.yml
+++ b/modules/wkhub_blog/config/install/core.entity_view_display.node.blog.default.yml
@@ -1,0 +1,66 @@
+uuid: 07f91eba-12c4-491f-8d00-c8c1bc2b638c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.blog.body
+    - field.field.node.blog.field_country
+    - field.field.node.blog.field_image
+    - field.field.node.blog.field_intro
+    - field.field.node.blog.field_kicker
+    - field.field.node.blog.field_tags
+    - node.type.blog
+  module:
+    - image
+    - text
+    - user
+id: node.blog.default
+targetEntityType: node
+bundle: blog
+mode: default
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 2
+    settings: {  }
+    third_party_settings: {  }
+  field_country:
+    weight: 6
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+  field_image:
+    weight: 0
+    label: hidden
+    settings:
+      image_style: large
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+  field_intro:
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+  field_kicker:
+    weight: 3
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+  field_tags:
+    weight: 5
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+  links:
+    weight: 4
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/modules/wkhub_blog/config/install/core.entity_view_display.node.blog.default.yml
+++ b/modules/wkhub_blog/config/install/core.entity_view_display.node.blog.default.yml
@@ -1,4 +1,3 @@
-uuid: 07f91eba-12c4-491f-8d00-c8c1bc2b638c
 langcode: en
 status: true
 dependencies:

--- a/modules/wkhub_blog/config/install/core.entity_view_display.node.blog.full.yml
+++ b/modules/wkhub_blog/config/install/core.entity_view_display.node.blog.full.yml
@@ -1,0 +1,61 @@
+uuid: 96333d90-0890-4305-ba36-54a0a8588712
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.full
+    - field.field.node.blog.body
+    - field.field.node.blog.field_country
+    - field.field.node.blog.field_image
+    - field.field.node.blog.field_intro
+    - field.field.node.blog.field_kicker
+    - field.field.node.blog.field_tags
+    - node.type.blog
+  module:
+    - image
+    - text
+    - user
+id: node.blog.full
+targetEntityType: node
+bundle: blog
+mode: full
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 2
+    settings: {  }
+    third_party_settings: {  }
+  field_image:
+    weight: 0
+    label: hidden
+    settings:
+      image_style: large
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+  field_intro:
+    type: text_default
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  field_kicker:
+    type: text_default
+    weight: 3
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  field_tags:
+    weight: 5
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+  links:
+    weight: 4
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  field_country: true

--- a/modules/wkhub_blog/config/install/core.entity_view_display.node.blog.full.yml
+++ b/modules/wkhub_blog/config/install/core.entity_view_display.node.blog.full.yml
@@ -1,4 +1,3 @@
-uuid: 96333d90-0890-4305-ba36-54a0a8588712
 langcode: en
 status: true
 dependencies:

--- a/modules/wkhub_blog/config/install/core.entity_view_display.node.blog.teaser.yml
+++ b/modules/wkhub_blog/config/install/core.entity_view_display.node.blog.teaser.yml
@@ -1,0 +1,42 @@
+uuid: 94d547d3-3d5c-4c94-a300-cb062174a8d2
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.blog.body
+    - field.field.node.blog.field_country
+    - field.field.node.blog.field_image
+    - field.field.node.blog.field_intro
+    - field.field.node.blog.field_kicker
+    - field.field.node.blog.field_tags
+    - node.type.blog
+  module:
+    - image
+    - text
+    - user
+id: node.blog.teaser
+targetEntityType: node
+bundle: blog
+mode: teaser
+content:
+  field_image:
+    type: image
+    weight: 0
+    label: hidden
+    settings:
+      image_style: medium
+      image_link: ''
+    third_party_settings: {  }
+  field_intro:
+    type: text_default
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  body: true
+  field_country: true
+  field_kicker: true
+  field_tags: true
+  links: true

--- a/modules/wkhub_blog/config/install/core.entity_view_display.node.blog.teaser.yml
+++ b/modules/wkhub_blog/config/install/core.entity_view_display.node.blog.teaser.yml
@@ -1,4 +1,3 @@
-uuid: 94d547d3-3d5c-4c94-a300-cb062174a8d2
 langcode: en
 status: true
 dependencies:

--- a/modules/wkhub_blog/config/install/field.field.node.blog.body.yml
+++ b/modules/wkhub_blog/config/install/field.field.node.blog.body.yml
@@ -1,4 +1,3 @@
-uuid: 02390361-5414-4cce-b406-6fb360f97ad4
 langcode: en
 status: true
 dependencies:

--- a/modules/wkhub_blog/config/install/field.field.node.blog.body.yml
+++ b/modules/wkhub_blog/config/install/field.field.node.blog.body.yml
@@ -1,0 +1,22 @@
+uuid: 02390361-5414-4cce-b406-6fb360f97ad4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.blog
+  module:
+    - text
+id: node.blog.body
+field_name: body
+entity_type: node
+bundle: blog
+label: Body
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: false
+field_type: text_with_summary

--- a/modules/wkhub_blog/config/install/field.field.node.blog.field_country.yml
+++ b/modules/wkhub_blog/config/install/field.field.node.blog.field_country.yml
@@ -1,4 +1,3 @@
-uuid: b95185ee-8df7-4522-9c00-b1c8ca36c1d5
 langcode: en
 status: true
 dependencies:

--- a/modules/wkhub_blog/config/install/field.field.node.blog.field_country.yml
+++ b/modules/wkhub_blog/config/install/field.field.node.blog.field_country.yml
@@ -1,0 +1,28 @@
+uuid: b95185ee-8df7-4522-9c00-b1c8ca36c1d5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_country
+    - node.type.blog
+  module:
+    - entity_reference
+id: node.blog.field_country
+field_name: field_country
+entity_type: node
+bundle: blog
+label: Country
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      country: country
+    sort:
+      field: _none
+    auto_create: false
+field_type: entity_reference

--- a/modules/wkhub_blog/config/install/field.field.node.blog.field_image.yml
+++ b/modules/wkhub_blog/config/install/field.field.node.blog.field_image.yml
@@ -1,0 +1,38 @@
+uuid: fd48c9f3-77d6-43e6-9a00-dfb3915a2811
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_image
+    - node.type.blog
+  module:
+    - image
+id: node.blog.field_image
+field_name: field_image
+entity_type: node
+bundle: blog
+label: Image
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: image/blog
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: true
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:node'
+  handler_settings: {  }
+field_type: image

--- a/modules/wkhub_blog/config/install/field.field.node.blog.field_image.yml
+++ b/modules/wkhub_blog/config/install/field.field.node.blog.field_image.yml
@@ -1,4 +1,3 @@
-uuid: fd48c9f3-77d6-43e6-9a00-dfb3915a2811
 langcode: en
 status: true
 dependencies:

--- a/modules/wkhub_blog/config/install/field.field.node.blog.field_intro.yml
+++ b/modules/wkhub_blog/config/install/field.field.node.blog.field_intro.yml
@@ -1,0 +1,21 @@
+uuid: 91fda7c0-4c97-4fa0-a300-e43bb4d31d2c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_intro
+    - node.type.blog
+  module:
+    - text
+id: node.blog.field_intro
+field_name: field_intro
+entity_type: node
+bundle: blog
+label: Deck/intro
+description: "The deck intro is used as the summary of your block. <strong>It is the first copy a reader reads. <em>It may be the only copy a reader reads.</em></strong>\r\n<ul>\r\n<li>summarises learnings to reader</li>\r\n<li>indicates reasons to keep reading</li>\r\n<li>keep to 1 longer or 2 shorter sentences</li>\r\n<li>aim for 25-30 words</li></ul>\r\n"
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/modules/wkhub_blog/config/install/field.field.node.blog.field_intro.yml
+++ b/modules/wkhub_blog/config/install/field.field.node.blog.field_intro.yml
@@ -1,4 +1,3 @@
-uuid: 91fda7c0-4c97-4fa0-a300-e43bb4d31d2c
 langcode: en
 status: true
 dependencies:

--- a/modules/wkhub_blog/config/install/field.field.node.blog.field_intro.yml
+++ b/modules/wkhub_blog/config/install/field.field.node.blog.field_intro.yml
@@ -11,7 +11,7 @@ field_name: field_intro
 entity_type: node
 bundle: blog
 label: Deck/intro
-description: "The deck intro is used as the summary of your block. <strong>It is the first copy a reader reads. <em>It may be the only copy a reader reads.</em></strong>\r\n<ul>\r\n<li>summarises learnings to reader</li>\r\n<li>indicates reasons to keep reading</li>\r\n<li>keep to 1 longer or 2 shorter sentences</li>\r\n<li>aim for 25-30 words</li></ul>\r\n"
+description: "The deck intro is used as the summary of your blog. <strong>It is the first copy a reader reads. <em>It may be the only copy a reader reads.</em></strong>\r\n<ul>\r\n<li>summarises learnings to reader</li>\r\n<li>indicates reasons to keep reading</li>\r\n<li>keep to 1 longer or 2 shorter sentences</li>\r\n<li>aim for 25-30 words</li></ul>\r\n"
 required: true
 translatable: false
 default_value: {  }

--- a/modules/wkhub_blog/config/install/field.field.node.blog.field_kicker.yml
+++ b/modules/wkhub_blog/config/install/field.field.node.blog.field_kicker.yml
@@ -1,0 +1,21 @@
+uuid: 4d5bef82-9b6b-4427-ba09-9a26d3d2057f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_kicker
+    - node.type.blog
+  module:
+    - text
+id: node.blog.field_kicker
+field_name: field_kicker
+entity_type: node
+bundle: blog
+label: Kicker
+description: "A call to action at the end of your blog entry. \r\n\r\n<ul><li>keep to 1 longer or 2 shorter sentences</li>\r\n<li>aim for 25-30 words</li></ul>"
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/modules/wkhub_blog/config/install/field.field.node.blog.field_kicker.yml
+++ b/modules/wkhub_blog/config/install/field.field.node.blog.field_kicker.yml
@@ -1,4 +1,3 @@
-uuid: 4d5bef82-9b6b-4427-ba09-9a26d3d2057f
 langcode: en
 status: true
 dependencies:

--- a/modules/wkhub_blog/config/install/field.field.node.blog.field_tags.yml
+++ b/modules/wkhub_blog/config/install/field.field.node.blog.field_tags.yml
@@ -1,0 +1,28 @@
+uuid: b048e7f0-fffe-4a81-bd00-c19ccc25c9be
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_tags
+    - node.type.blog
+  module:
+    - entity_reference
+id: node.blog.field_tags
+field_name: field_tags
+entity_type: node
+bundle: blog
+label: Tags
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      tags: tags
+    sort:
+      field: _none
+    auto_create: true
+field_type: entity_reference

--- a/modules/wkhub_blog/config/install/field.field.node.blog.field_tags.yml
+++ b/modules/wkhub_blog/config/install/field.field.node.blog.field_tags.yml
@@ -1,4 +1,3 @@
-uuid: b048e7f0-fffe-4a81-bd00-c19ccc25c9be
 langcode: en
 status: true
 dependencies:

--- a/modules/wkhub_blog/config/install/field.storage.node.field_country.yml
+++ b/modules/wkhub_blog/config/install/field.storage.node.field_country.yml
@@ -1,4 +1,3 @@
-uuid: 309e4818-77e3-4c19-b900-f46194f26224
 langcode: en
 status: true
 dependencies:

--- a/modules/wkhub_blog/config/install/field.storage.node.field_country.yml
+++ b/modules/wkhub_blog/config/install/field.storage.node.field_country.yml
@@ -1,0 +1,19 @@
+uuid: 309e4818-77e3-4c19-b900-f46194f26224
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference
+    - node
+id: node.field_country
+field_name: field_country
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: entity_reference
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false

--- a/modules/wkhub_blog/config/install/field.storage.node.field_image.yml
+++ b/modules/wkhub_blog/config/install/field.storage.node.field_image.yml
@@ -1,4 +1,3 @@
-uuid: 41d8021f-bd63-4e95-a441-65cb6715b9a8
 langcode: en
 status: true
 dependencies:

--- a/modules/wkhub_blog/config/install/field.storage.node.field_image.yml
+++ b/modules/wkhub_blog/config/install/field.storage.node.field_image.yml
@@ -1,0 +1,31 @@
+uuid: 41d8021f-bd63-4e95-a441-65cb6715b9a8
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - image
+id: node.field_image
+field_name: field_image
+entity_type: node
+type: image
+settings:
+  uri_scheme: public
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+  target_bundle: null
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes:
+  target_id:
+    - target_id
+persist_with_no_fields: false

--- a/modules/wkhub_blog/config/install/field.storage.node.field_intro.yml
+++ b/modules/wkhub_blog/config/install/field.storage.node.field_intro.yml
@@ -1,0 +1,18 @@
+uuid: 1d57cb5c-29cb-4da1-b000-a6d81d3be4df
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - text
+id: node.field_intro
+field_name: field_intro
+entity_type: node
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false

--- a/modules/wkhub_blog/config/install/field.storage.node.field_intro.yml
+++ b/modules/wkhub_blog/config/install/field.storage.node.field_intro.yml
@@ -1,4 +1,3 @@
-uuid: 1d57cb5c-29cb-4da1-b000-a6d81d3be4df
 langcode: en
 status: true
 dependencies:

--- a/modules/wkhub_blog/config/install/field.storage.node.field_kicker.yml
+++ b/modules/wkhub_blog/config/install/field.storage.node.field_kicker.yml
@@ -1,0 +1,18 @@
+uuid: fa1cf4f0-c62b-484a-9e34-5263fc3018e6
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - text
+id: node.field_kicker
+field_name: field_kicker
+entity_type: node
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false

--- a/modules/wkhub_blog/config/install/field.storage.node.field_kicker.yml
+++ b/modules/wkhub_blog/config/install/field.storage.node.field_kicker.yml
@@ -1,4 +1,3 @@
-uuid: fa1cf4f0-c62b-484a-9e34-5263fc3018e6
 langcode: en
 status: true
 dependencies:

--- a/modules/wkhub_blog/config/install/field.storage.node.field_tags.yml
+++ b/modules/wkhub_blog/config/install/field.storage.node.field_tags.yml
@@ -1,4 +1,3 @@
-uuid: 9f7794a1-26ee-4237-9546-700c7d480ba1
 langcode: en
 status: true
 dependencies:

--- a/modules/wkhub_blog/config/install/field.storage.node.field_tags.yml
+++ b/modules/wkhub_blog/config/install/field.storage.node.field_tags.yml
@@ -1,0 +1,19 @@
+uuid: 9f7794a1-26ee-4237-9546-700c7d480ba1
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference
+    - node
+id: node.field_tags
+field_name: field_tags
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: entity_reference
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false

--- a/modules/wkhub_blog/config/install/node.type.blog.yml
+++ b/modules/wkhub_blog/config/install/node.type.blog.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies: {  }
+name: Blog
+type: blog
+description: 'A post on our company blog.'
+help: ''
+new_revision: false
+preview_mode: 1
+display_submitted: true

--- a/modules/wkhub_blog/config/install/views.view.blog.yml
+++ b/modules/wkhub_blog/config/install/views.view.blog.yml
@@ -399,7 +399,10 @@ display:
           hide_alter_empty: true
           click_sort_column: value
           type: timestamp
-          settings: {  }
+          settings:
+            date_format: html_datetime
+            custom_date_format: ''
+            timezone: ''
           group_column: value
           group_columns: {  }
           group_rows: true

--- a/modules/wkhub_blog/config/install/views.view.blog.yml
+++ b/modules/wkhub_blog/config/install/views.view.blog.yml
@@ -72,10 +72,10 @@ display:
             first: '« first'
             last: 'last »'
           expose:
-            items_per_page: false
+            items_per_page: true
             items_per_page_label: 'Items per page'
             items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
+            items_per_page_options_all: true
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
@@ -1500,10 +1500,10 @@ display:
             first: '« first'
             last: 'last »'
           expose:
-            items_per_page: false
+            items_per_page: true
             items_per_page_label: 'Items per page'
             items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
+            items_per_page_options_all: true
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset

--- a/modules/wkhub_blog/config/install/views.view.blog.yml
+++ b/modules/wkhub_blog/config/install/views.view.blog.yml
@@ -413,6 +413,57 @@ display:
           entity_type: node
           entity_field: changed
           plugin_id: field
+        path:
+          id: path
+          table: node
+          field: path
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          absolute: false
+          entity_type: node
+          plugin_id: node_path
         title:
           id: title
           table: node_field_data
@@ -1264,6 +1315,9 @@ display:
               raw_output: false
             changed:
               alias: changed
+              raw_output: false
+            path:
+              alias: path
               raw_output: false
             title:
               alias: title

--- a/modules/wkhub_blog/config/install/views.view.blog.yml
+++ b/modules/wkhub_blog/config/install/views.view.blog.yml
@@ -1,4 +1,3 @@
-uuid: bdeb2bae-1aa3-47bf-a000-e8cb22ba6ff7
 langcode: en
 status: true
 dependencies:
@@ -66,6 +65,11 @@ display:
           offset: 0
           id: 0
           total_pages: null
+          tags:
+            previous: '‹ previous'
+            next: 'next ›'
+            first: '« first'
+            last: 'last »'
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'
@@ -74,11 +78,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          tags:
-            previous: '‹ previous'
-            next: 'next ›'
-            first: '« first'
-            last: 'last »'
           quantity: 9
       style:
         type: default
@@ -1297,10 +1296,26 @@ display:
               alias: image_large
               raw_output: false
       pager:
-        type: some
+        type: full
         options:
           items_per_page: 10
           offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: '‹ previous'
+            next: 'next ›'
+            first: '« first'
+            last: 'last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
       display_description: ''
     cache_metadata:
       contexts:
@@ -1308,6 +1323,7 @@ display:
         - 'languages:language_interface'
         - request_format
         - url
+        - url.query_args
         - 'user.node_grants:view'
         - user.permissions
       cacheable: false

--- a/modules/wkhub_blog/config/install/views.view.blog.yml
+++ b/modules/wkhub_blog/config/install/views.view.blog.yml
@@ -1,0 +1,1463 @@
+uuid: bdeb2bae-1aa3-47bf-a000-e8cb22ba6ff7
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.storage.node.body
+    - field.storage.node.field_country
+    - field.storage.node.field_image
+    - field.storage.node.field_intro
+    - field.storage.node.field_kicker
+    - field.storage.node.field_tags
+    - node.type.blog
+  module:
+    - image_raw_formatter
+    - node
+    - rest
+    - taxonomy
+    - text
+    - user
+    - wkhub_blog
+id: blog
+label: Blog
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: full
+        options:
+          items_per_page: 10
+          offset: 0
+          id: 0
+          total_pages: null
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          tags:
+            previous: '‹ previous'
+            next: 'next ›'
+            first: '« first'
+            last: 'last »'
+          quantity: 9
+      style:
+        type: default
+      row:
+        type: 'entity:node'
+        options:
+          view_mode: teaser
+      fields:
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_unformatted
+          settings:
+            thousand_separator: ''
+            prefix_suffix: 0
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: nid
+          plugin_id: field
+        uuid:
+          id: uuid
+          table: node
+          field: uuid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: uuid
+          plugin_id: field
+        uid:
+          id: uid
+          table: node_field_data
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: uid
+          plugin_id: field
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: html_datetime
+            custom_date_format: ''
+            timezone: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: created
+          plugin_id: field
+        changed:
+          id: changed
+          table: node_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: changed
+          plugin_id: field
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+        field_intro:
+          id: field_intro
+          table: node__field_intro
+          field: field_intro
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        body:
+          id: body
+          table: node__body
+          field: body
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_kicker:
+          id: field_kicker
+          table: node__field_kicker
+          field: field_kicker
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_country:
+          id: field_country
+          table: node__field_country
+          field: field_country
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_tags:
+          id: field_tags
+          table: node__field_tags
+          field: field_tags
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_image:
+          id: field_image
+          table: node__field_image
+          field: field_image
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: image_raw_formatter
+          settings:
+            image_style: ''
+            image_link: ''
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_image_1:
+          id: field_image_1
+          table: node__field_image
+          field: field_image
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: thumb
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: image_raw_formatter
+          settings:
+            image_style: thumbnail
+            image_link: ''
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_image_2:
+          id: field_image_2
+          table: node__field_image
+          field: field_image
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: medium
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: image_raw_formatter
+          settings:
+            image_style: medium
+            image_link: ''
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_image_3:
+          id: field_image_3
+          table: node__field_image
+          field: field_image
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: large
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: image_raw_formatter
+          settings:
+            image_style: large
+            image_link: ''
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+      filters:
+        status:
+          value: true
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            blog: blog
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        uid:
+          id: uid
+          table: users
+          field: uid
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: uid_op
+            label: 'User ID'
+            description: ''
+            use_operator: false
+            operator: uid_op
+            identifier: uid
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              employee: '0'
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: user
+          entity_field: uid
+          plugin_id: numeric
+        name:
+          id: name
+          table: taxonomy_term_field_data
+          field: name
+          relationship: field_country
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: name_op
+            label: Country
+            description: ''
+            use_operator: false
+            operator: name_op
+            identifier: country
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              employee: '0'
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: Name
+            description: ''
+            identifier: name
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: 'United Kingdom'
+                operator: '='
+                value: 'United Kingdom'
+              2:
+                title: Germany
+                operator: '='
+                value: Germany
+              3:
+                title: ''
+                operator: '='
+                value: ''
+          entity_type: taxonomy_term
+          entity_field: name
+          plugin_id: string
+      sorts:
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          order: DESC
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+      title: Blog
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships:
+        uid:
+          id: uid
+          table: node_field_data
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: author
+          required: true
+          entity_type: node
+          entity_field: uid
+          plugin_id: standard
+        field_country:
+          id: field_country
+          table: node__field_country
+          field: field_country
+          relationship: none
+          group_type: group
+          admin_label: 'field_country: Taxonomy term'
+          required: false
+          plugin_id: standard
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      cacheable: false
+  page_1:
+    display_plugin: page
+    id: page_1
+    display_title: Page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: blog
+    cache_metadata:
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      cacheable: false
+  rest_export_1:
+    display_plugin: rest_export
+    id: rest_export_1
+    display_title: 'API Listing'
+    position: 2
+    display_options:
+      display_extenders: {  }
+      path: api/blog
+      style:
+        type: serializer
+      defaults:
+        style: false
+        row: false
+      row:
+        type: data_field
+        options:
+          field_options:
+            nid:
+              alias: nid
+              raw_output: false
+            uuid:
+              alias: uuid
+              raw_output: false
+            uid:
+              alias: uid
+              raw_output: false
+            created:
+              alias: created
+              raw_output: false
+            changed:
+              alias: changed
+              raw_output: false
+            title:
+              alias: title
+              raw_output: false
+            field_intro:
+              alias: intro
+              raw_output: false
+            body:
+              alias: body
+              raw_output: false
+            field_kicker:
+              alias: kicker
+              raw_output: false
+            field_country:
+              alias: country
+              raw_output: false
+            field_tags:
+              alias: tags
+              raw_output: false
+            field_image:
+              alias: image
+              raw_output: false
+            field_image_1:
+              alias: image_thumb
+              raw_output: false
+            field_image_2:
+              alias: image_medium
+              raw_output: false
+            field_image_3:
+              alias: image_large
+              raw_output: false
+      pager:
+        type: some
+        options:
+          items_per_page: 10
+          offset: 0
+      display_description: ''
+    cache_metadata:
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - request_format
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      cacheable: false
+  rest_export_2:
+    display_plugin: rest_export
+    id: rest_export_2
+    display_title: 'API Item'
+    position: 2
+    display_options:
+      display_extenders: {  }
+      path: api/blog/%
+      style:
+        type: serializer
+      defaults:
+        style: false
+        row: false
+        filters: false
+        filter_groups: false
+        arguments: false
+        relationships: false
+      row:
+        type: data_field
+        options:
+          field_options:
+            nid:
+              alias: nid
+              raw_output: false
+            uuid:
+              alias: uuid
+              raw_output: false
+            uid:
+              alias: uid
+              raw_output: false
+            created:
+              alias: created
+              raw_output: false
+            changed:
+              alias: changed
+              raw_output: false
+            title:
+              alias: title
+              raw_output: false
+            field_intro:
+              alias: intro
+              raw_output: false
+            body:
+              alias: body
+              raw_output: false
+            field_kicker:
+              alias: kicker
+              raw_output: false
+            field_country:
+              alias: country
+              raw_output: false
+            field_tags:
+              alias: tags
+              raw_output: false
+            field_image:
+              alias: image
+              raw_output: false
+            field_image_1:
+              alias: image_thumb
+              raw_output: false
+            field_image_2:
+              alias: image_medium
+              raw_output: false
+            field_image_3:
+              alias: image_large
+              raw_output: false
+      pager:
+        type: some
+        options:
+          items_per_page: 10
+          offset: 0
+      display_description: ''
+      filters:
+        status:
+          value: true
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            blog: blog
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          group: 1
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      arguments:
+        uuid_1:
+          id: uuid_1
+          table: node
+          field: uuid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: 'not found'
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: false
+          entity_type: node
+          entity_field: uuid
+          plugin_id: string
+      relationships: {  }
+    cache_metadata:
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - request_format
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      cacheable: false

--- a/modules/wkhub_blog/config/install/views.view.blog.yml
+++ b/modules/wkhub_blog/config/install/views.view.blog.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.storage.node.field_tags
     - node.type.blog
   module:
+    - image
     - image_raw_formatter
     - node
     - rest
@@ -908,6 +909,134 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
+        field_image_4:
+          id: field_image_4
+          table: node__field_image
+          field: field_image
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'image alt'
+          exclude: false
+          alter:
+            alter_text: true
+            text: '{{ field_image_4__alt }}'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: image
+          settings:
+            image_style: ''
+            image_link: ''
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_image_5:
+          id: field_image_5
+          table: node__field_image
+          field: field_image
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'image title'
+          exclude: false
+          alter:
+            alter_text: true
+            text: '{{ field_image_5__title }}'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: image
+          settings:
+            image_style: ''
+            image_link: ''
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
         field_image_1:
           id: field_image_1
           table: node__field_image
@@ -1343,6 +1472,12 @@ display:
             field_image:
               alias: image
               raw_output: false
+            field_image_4:
+              alias: image_alt
+              raw_output: false
+            field_image_5:
+              alias: image_title
+              raw_output: false
             field_image_1:
               alias: image_thumb
               raw_output: false
@@ -1420,6 +1555,9 @@ display:
             changed:
               alias: changed
               raw_output: false
+            path:
+              alias: ''
+              raw_output: false
             title:
               alias: title
               raw_output: false
@@ -1449,6 +1587,12 @@ display:
               raw_output: false
             field_image_3:
               alias: image_large
+              raw_output: false
+            field_image_4:
+              alias: image_alt
+              raw_output: false
+            field_image_5:
+              alias: image_title
               raw_output: false
       pager:
         type: some

--- a/modules/wkhub_blog/config/install/views.view.blog.yml
+++ b/modules/wkhub_blog/config/install/views.view.blog.yml
@@ -266,9 +266,9 @@ display:
           empty_zero: false
           hide_alter_empty: true
           click_sort_column: target_id
-          type: entity_reference_label
+          type: entity_reference_entity_id
           settings:
-            link: false
+            link: 0
           group_column: target_id
           group_columns: {  }
           group_rows: true

--- a/modules/wkhub_blog/src/Plugin/views/display/WunderBlogRestExport.php
+++ b/modules/wkhub_blog/src/Plugin/views/display/WunderBlogRestExport.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @file
+ * Contains \Drupal\wkhub_blog\Plugin\views\display\WunderBlogRestExport.
+ */
+
+namespace Drupal\wkhub_blog\Plugin\views\display;
+
+use Drupal\views\Plugin\views\display\ResponseDisplayPluginInterface;
+use Drupal\rest\Plugin\views\display\RestExport;
+
+/**
+ * The plugin that handles Data response callbacks for REST resources.
+ *
+ * @ingroup views_display_plugins
+ *
+ * @ViewsDisplay(
+ *   id = "rest_export",
+ *   title = @Translation("REST export"),
+ *   help = @Translation("Create a REST export resource."),
+ *   uses_route = TRUE,
+ *   admin = @Translation("REST export"),
+ *   returns_response = TRUE
+ * )
+ */
+class WunderBlogRestExport extends RestExport implements ResponseDisplayPluginInterface {
+  /**
+   * {@inheritdoc}
+   */
+  public function usesExposed() {
+    return TRUE;
+  }
+}

--- a/modules/wkhub_blog/wkhub_blog.info.yml
+++ b/modules/wkhub_blog/wkhub_blog.info.yml
@@ -1,0 +1,9 @@
+name: WunderBlog
+type: module
+core: '8.x'
+project: 'wkhub_blog'
+description: 'Wundersites::Hub: Blog.'
+package: Wundersites
+#dependencies:
+#  - views
+#  - entity_reference

--- a/modules/wkhub_blog/wkhub_blog.info.yml
+++ b/modules/wkhub_blog/wkhub_blog.info.yml
@@ -4,6 +4,6 @@ core: '8.x'
 project: 'wkhub_blog'
 description: 'Wundersites::Hub: Blog.'
 package: Wundersites
-#dependencies:
-#  - views
-#  - entity_reference
+dependencies:
+  - views
+  - entity_reference

--- a/wk.info.yml
+++ b/wk.info.yml
@@ -41,6 +41,7 @@ dependencies:
   - views_ui
   - wkhub_company
   - wkhub_person
+  - wkhub_blog
 themes:
   - bartik
   - seven


### PR DESCRIPTION
This is the first draft of blog support functionality only. Adds blog content type, with fields for:

- title
- intro/deck
- body
- kicker
- image
- country

API endpoints at:

- Blog list: api/blog
  - with URL query support for filtering by:
    - author uid, e.g.: ?uid={uid}
    - country name, e.g.: ?country=United+Kingdom
  - plus pager: ?page={page_number}
- Blog item: api/blog/{uuid}