### PR TITLE
Add new text filter to set all internal image URLs to absolute URLs

### DIFF
--- a/config/install/editor.editor.basic_html.yml
+++ b/config/install/editor.editor.basic_html.yml
@@ -35,6 +35,7 @@ settings:
           name: Tools
           items:
             - Source
+            - Format
             - Styles
   plugins:
     stylescombo:

--- a/config/install/filter.format.basic_html.yml
+++ b/config/install/filter.format.basic_html.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   module:
     - editor
+    - wk
 name: 'Basic HTML'
 format: basic_html
 weight: 0
@@ -11,7 +12,7 @@ filters:
     id: filter_html
     provider: filter
     status: true
-    weight: -10
+    weight: -50
     settings:
       allowed_html: '<a> <em> <strong> <cite> <blockquote> <code> <ul> <ol> <li> <dl> <dt> <dd> <h4> <h5> <h6> <p> <br> <span> <img> <h1> <h2> <h3> <h4> <h5> <h6>'
       filter_html_help: false
@@ -20,29 +21,54 @@ filters:
     id: filter_align
     provider: filter
     status: true
-    weight: 7
+    weight: -49
     settings: {  }
   filter_caption:
     id: filter_caption
     provider: filter
     status: true
-    weight: 8
+    weight: -48
     settings: {  }
   filter_html_image_secure:
     id: filter_html_image_secure
     provider: filter
     status: true
-    weight: 9
+    weight: -47
     settings: {  }
   filter_htmlcorrector:
     id: filter_htmlcorrector
     provider: filter
     status: true
-    weight: 10
+    weight: -46
     settings: {  }
   editor_file_reference:
     id: editor_file_reference
     provider: editor
     status: true
-    weight: 11
+    weight: -45
     settings: {  }
+  filter_image_absolute_urls:
+    id: filter_image_absolute_urls
+    provider: wk
+    status: true
+    weight: -44
+    settings: {  }
+  filter_autop:
+    id: filter_autop
+    provider: filter
+    status: false
+    weight: -42
+    settings: {  }
+  filter_html_escape:
+    id: filter_html_escape
+    provider: filter
+    status: false
+    weight: -43
+    settings: {  }
+  filter_url:
+    id: filter_url
+    provider: filter
+    status: false
+    weight: -41
+    settings:
+      filter_url_length: 72

--- a/src/Plugin/Filter/WunderHubFilterImageAbsoluteUrls.php
+++ b/src/Plugin/Filter/WunderHubFilterImageAbsoluteUrls.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\wk\Plugin\Filter\WunderHubFilterImageAbsoluteUrls.
+ */
+
+namespace Drupal\wk\Plugin\Filter;
+
+use Drupal\Component\Utility\Html;
+use Drupal\Component\Utility\Unicode;
+use Drupal\Core\Url;
+use Drupal\filter\FilterProcessResult;
+use Drupal\filter\Plugin\FilterBase;
+
+/**
+ * Provides a filter to caption elements.
+ *
+ * When used in combination with the filter_align filter, this must run last.
+ *
+ * @Filter(
+ *   id = "filter_image_absolute_urls",
+ *   title = @Translation("Absolute URLs for images"),
+ *   description = @Translation("Ensure all images have absolute URLs."),
+ *   type = Drupal\filter\Plugin\FilterInterface::TYPE_TRANSFORM_REVERSIBLE
+ * )
+ */
+class WunderHubFilterImageAbsoluteUrls extends FilterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function process($text, $langcode) {
+    $result = new FilterProcessResult($text);
+    if (stristr($text, '<img ') !== FALSE) {
+      $dom = Html::load($text);
+      $images = $dom->getElementsByTagName('img');
+      foreach ($images as $image) {
+        $src = $image->getAttribute("src");
+
+        // The src must be non-empty.
+        if (Unicode::strlen($src) === 0) {
+          continue;
+        }
+        // The src must not already be an external URL
+        if (stristr($src, 'http://') !== FALSE || stristr($src, 'https://') !== FALSE) {
+          continue;
+        }
+        $url = Url::fromUri('internal:' . $src, array('absolute' => TRUE));
+        $url_string = $url->toString();
+        $image->setAttribute('src', $url_string);
+      }
+
+      $result->setProcessedText(Html::serialize($dom));
+    }
+
+    return $result;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function tips($long = FALSE) {
+    return $this->t('URLs for images will be automatically turned into absolute URLs.');
+  }
+}


### PR DESCRIPTION
Plus config in basic HTML editor.

This is needed because if someone inserts an image inline into e.g. a blog, by default the URL in the image src is a relative URL - Drupal's assuming it's for use on the Hub site itself, of course. But, if someone wants to use that blog on e.g. a country site, then the relative URL is no good. So, the filter automatically rewrites relative URLs to absolute ones.