### PR TITLE
Create Composer.JSON

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,6 @@
+{
+  "name": "drupal/wunderhub",
+  "description": "Install profile for the wunderhub REST API.",
+  "type": "drupal-profile",
+  "license": "GPL-2.0+"
+}


### PR DESCRIPTION
Tested that with a local install that uses composer workflow with a manual repository entry and profile will be cloned into `profiles/contrib/wunderhub`

The repository entry in the main project's composer file is as follows:
```
  "repositories": [
    {
      "type": "git",
      "url": "https://github.com/pixelmord/wunderhub.git"
    },
    {
      "type": "composer",
      "url": "https://packagist.drupal-composer.org"
    }
  ],
```