### PR TITLE
IS53 skills and interests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "drupal/field_group": "8.1.0-rc3",
         "drupal/restui": "8.1.10",
         "drupal/devel": "8.1.*@dev",
-        "drupal/config_devel": "8.1.0-beta16"
+        "drupal/config_devel": "8.1.0-beta16",
+        "drupal/paragraphs": "8.1.0-rc4"
     },
     "require-dev": {
         "behat/mink": "~1.6",

--- a/config/staging/core.entity_form_display.paragraph.skills_and_interests.default.yml
+++ b/config/staging/core.entity_form_display.paragraph.skills_and_interests.default.yml
@@ -1,0 +1,29 @@
+uuid: 35830cd6-1927-4661-9403-3c98fdca5a73
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.skills_and_interests.field_skill_level
+    - field.field.paragraph.skills_and_interests.field_skills_and_interests
+    - paragraphs.paragraphs_type.skills_and_interests
+id: paragraph.skills_and_interests.default
+targetEntityType: paragraph
+bundle: skills_and_interests
+mode: default
+content:
+  field_skill_level:
+    weight: 1
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+  field_skills_and_interests:
+    weight: 0
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+hidden:
+  created: true
+  uid: true

--- a/config/staging/core.entity_form_display.taxonomy_term.skills_and_interests.default.yml
+++ b/config/staging/core.entity_form_display.taxonomy_term.skills_and_interests.default.yml
@@ -1,0 +1,41 @@
+uuid: 3cd4b277-497d-4da8-be3d-618d254bc729
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.skills_and_interests
+  module:
+    - path
+    - text
+id: taxonomy_term.skills_and_interests.default
+targetEntityType: taxonomy_term
+bundle: skills_and_interests
+mode: default
+content:
+  description:
+    type: text_textfield
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    settings: {  }
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: -5
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    settings: {  }
+    third_party_settings: {  }
+  translation:
+    weight: 10
+hidden: {  }

--- a/config/staging/core.entity_form_display.user.user.default.yml
+++ b/config/staging/core.entity_form_display.user.user.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.user.user.field_person_namefirst
     - field.field.user.user.field_person_namelast
     - field.field.user.user.field_person_office
+    - field.field.user.user.field_person_skills
     - field.field.user.user.field_persongender
     - field.field.user.user.field_twitter
     - field.field.user.user.user_picture
@@ -19,6 +20,7 @@ dependencies:
     - field_group
     - image
     - link
+    - paragraphs
     - text
     - user
 third_party_settings:
@@ -109,6 +111,16 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
+  field_person_skills:
+    type: entity_reference_paragraphs
+    weight: 18
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      add_mode: dropdown
+      form_display_mode: default
+    third_party_settings: {  }
   field_persongender:
     weight: 3
     settings: {  }
@@ -129,6 +141,8 @@ content:
     weight: 10
     settings: {  }
     third_party_settings: {  }
+  translation:
+    weight: 10
   user_picture:
     type: image_image
     settings:

--- a/config/staging/core.entity_view_display.paragraph.skills_and_interests.default.yml
+++ b/config/staging/core.entity_view_display.paragraph.skills_and_interests.default.yml
@@ -1,0 +1,31 @@
+uuid: a3022030-3baf-4707-8c00-b509ece69e26
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.skills_and_interests.field_skill_level
+    - field.field.paragraph.skills_and_interests.field_skills_and_interests
+    - paragraphs.paragraphs_type.skills_and_interests
+  module:
+    - options
+id: paragraph.skills_and_interests.default
+targetEntityType: paragraph
+bundle: skills_and_interests
+mode: default
+content:
+  field_skill_level:
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+  field_skills_and_interests:
+    weight: 0
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_label
+hidden:
+  created: true
+  uid: true

--- a/config/staging/core.entity_view_display.taxonomy_term.skills_and_interests.default.yml
+++ b/config/staging/core.entity_view_display.taxonomy_term.skills_and_interests.default.yml
@@ -1,0 +1,21 @@
+uuid: eb8267c1-ad64-4ae2-a002-2ad00b3b4d61
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.skills_and_interests
+  module:
+    - text
+id: taxonomy_term.skills_and_interests.default
+targetEntityType: taxonomy_term
+bundle: skills_and_interests
+mode: default
+content:
+  description:
+    label: hidden
+    type: text_default
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  langcode: true

--- a/config/staging/core.entity_view_display.user.user.default.yml
+++ b/config/staging/core.entity_view_display.user.user.default.yml
@@ -12,10 +12,12 @@ dependencies:
     - field.field.user.user.field_person_namefirst
     - field.field.user.user.field_person_namelast
     - field.field.user.user.field_person_office
+    - field.field.user.user.field_person_skills
     - field.field.user.user.field_persongender
     - field.field.user.user.field_twitter
     - field.field.user.user.user_picture
   module:
+    - entity_reference_revisions
     - image
     - link
     - text
@@ -64,6 +66,14 @@ content:
       target: ''
     third_party_settings: {  }
     type: link
+  field_person_skills:
+    type: entity_reference_revisions_entity_view
+    weight: 11
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
   field_twitter:
     weight: 9
     label: above

--- a/config/staging/core.entity_view_mode.paragraph.preview.yml
+++ b/config/staging/core.entity_view_mode.paragraph.preview.yml
@@ -1,0 +1,10 @@
+uuid: d4385389-b4a7-4cf2-a528-4016f3be9e3c
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.preview
+label: Preview
+targetEntityType: paragraph
+cache: true

--- a/config/staging/core.extension.yml
+++ b/config/staging/core.extension.yml
@@ -12,6 +12,7 @@ module:
   dblog: 0
   editor: 0
   entity_reference: 0
+  entity_reference_revisions: 0
   field: 0
   field_group: 0
   field_ui: 0
@@ -28,6 +29,7 @@ module:
   menutree_resource: 0
   node: 0
   options: 0
+  paragraphs: 0
   path: 0
   rdf: 0
   rest: 0

--- a/config/staging/field.field.paragraph.skills_and_interests.field_skill_level.yml
+++ b/config/staging/field.field.paragraph.skills_and_interests.field_skill_level.yml
@@ -1,0 +1,21 @@
+uuid: f63ff9fe-5596-4f0a-b100-bb61f99e8b3a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_skill_level
+    - paragraphs.paragraphs_type.skills_and_interests
+  module:
+    - options
+id: paragraph.skills_and_interests.field_skill_level
+field_name: field_skill_level
+entity_type: paragraph
+bundle: skills_and_interests
+label: Level
+description: 'Approximate skill level'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/staging/field.field.paragraph.skills_and_interests.field_skills_and_interests.yml
+++ b/config/staging/field.field.paragraph.skills_and_interests.field_skills_and_interests.yml
@@ -1,0 +1,27 @@
+uuid: a45cebb6-1007-4362-8400-e3ce1d1853f9
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_skills_and_interests
+    - paragraphs.paragraphs_type.skills_and_interests
+    - taxonomy.vocabulary.skills_and_interests
+id: paragraph.skills_and_interests.field_skills_and_interests
+field_name: field_skills_and_interests
+entity_type: paragraph
+bundle: skills_and_interests
+label: 'Skill or interest'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      skills_and_interests: skills_and_interests
+    sort:
+      field: _none
+    auto_create: true
+field_type: entity_reference

--- a/config/staging/field.field.user.user.field_person_skills.yml
+++ b/config/staging/field.field.user.user.field_person_skills.yml
@@ -1,0 +1,23 @@
+uuid: bac9d1de-efa6-4ba7-9e00-b6bb3bbd1a91
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_person_skills
+  module:
+    - entity_reference_revisions
+    - user
+id: user.user.field_person_skills
+field_name: field_person_skills
+entity_type: user
+bundle: user
+label: 'Skills and interests'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings: {  }
+field_type: entity_reference_revisions

--- a/config/staging/field.storage.paragraph.field_skill_level.yml
+++ b/config/staging/field.storage.paragraph.field_skill_level.yml
@@ -1,0 +1,36 @@
+uuid: 7b7d5b46-8db0-4b10-8100-c50b21d6262b
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+id: paragraph.field_skill_level
+field_name: field_skill_level
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: novice
+      label: Novice
+    -
+      value: apprentice
+      label: Apprentice
+    -
+      value: practitioner
+      label: Practitioner
+    -
+      value: expert
+      label: Expert
+    -
+      value: master
+      label: 'Jedi Master'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/staging/field.storage.paragraph.field_skills_and_interests.yml
+++ b/config/staging/field.storage.paragraph.field_skills_and_interests.yml
@@ -1,0 +1,20 @@
+uuid: 1128e5c9-4498-4143-b605-05a56ea0de9a
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - taxonomy
+id: paragraph.field_skills_and_interests
+field_name: field_skills_and_interests
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/staging/field.storage.user.field_person_skills.yml
+++ b/config/staging/field.storage.user.field_person_skills.yml
@@ -1,0 +1,21 @@
+uuid: 98c2187a-91b8-489a-8751-81c8e2172bb8
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+    - user
+id: user.field_person_skills
+field_name: field_person_skills
+entity_type: user
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/staging/language.content_settings.taxonomy_term.skills_and_interests.yml
+++ b/config/staging/language.content_settings.taxonomy_term.skills_and_interests.yml
@@ -1,0 +1,16 @@
+uuid: df240ecb-12e3-494e-9f61-974ba158799b
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.skills_and_interests
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: taxonomy_term.skills_and_interests
+target_entity_type_id: taxonomy_term
+target_bundle: skills_and_interests
+default_langcode: site_default
+language_alterable: true

--- a/config/staging/paragraphs.paragraphs_type.skills_and_interests.yml
+++ b/config/staging/paragraphs.paragraphs_type.skills_and_interests.yml
@@ -1,0 +1,6 @@
+uuid: c6f6dfe2-3e8a-4658-aa09-9c0e3fb1e75b
+langcode: en
+status: true
+dependencies: {  }
+id: skills_and_interests
+label: 'Skills and interests'

--- a/config/staging/taxonomy.vocabulary.skills_and_interests.yml
+++ b/config/staging/taxonomy.vocabulary.skills_and_interests.yml
@@ -1,0 +1,9 @@
+uuid: 0db32c57-ae23-4298-a71b-27ec40baa3e4
+langcode: en
+status: true
+dependencies: {  }
+name: 'Skills and interests'
+vid: skills_and_interests
+description: 'Staff skills and interests, with weights'
+hierarchy: 0
+weight: 0

--- a/config/staging/user.role.anonymous.yml
+++ b/config/staging/user.role.anonymous.yml
@@ -14,3 +14,5 @@ permissions:
   - 'access site-wide contact form'
   - 'restful get entity:node'
   - 'access user profiles'
+  - 'access rest_api_doc'
+  - 'restful get root'

--- a/config/staging/user.role.authenticated.yml
+++ b/config/staging/user.role.authenticated.yml
@@ -17,3 +17,5 @@ permissions:
   - 'access shortcuts'
   - 'restful get entity:node'
   - 'access user profiles'
+  - 'access rest_api_doc'
+  - 'restful get root'

--- a/config/staging/views.view.team_listing.yml
+++ b/config/staging/views.view.team_listing.yml
@@ -13,11 +13,13 @@ dependencies:
     - field.storage.user.field_person_namefirst
     - field.storage.user.field_person_namelast
     - field.storage.user.field_person_office
+    - field.storage.user.field_person_skills
     - field.storage.user.field_twitter
     - field.storage.user.user_picture
     - taxonomy.vocabulary.country
     - user.role.employee
   module:
+    - entity_reference_revisions
     - image_raw_formatter
     - link
     - rest
@@ -1664,6 +1666,69 @@ display:
           entity_type: user
           entity_field: preferred_langcode
           plugin_id: field
+        field_person_skills:
+          id: field_person_skills
+          table: user__field_person_skills
+          field: field_person_skills
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: '{{ field_person_skills__target_id }'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_revisions_entity_view
+          settings:
+            view_mode: default
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
       filters:
         status:
           value: true
@@ -1957,6 +2022,7 @@ display:
         - 'config:field.storage.user.field_person_namefirst'
         - 'config:field.storage.user.field_person_namelast'
         - 'config:field.storage.user.field_person_office'
+        - 'config:field.storage.user.field_person_skills'
         - 'config:field.storage.user.field_twitter'
         - 'config:field.storage.user.user_picture'
   rest_export_1:
@@ -2043,6 +2109,9 @@ display:
             preferred_langcode:
               alias: langcode_user_preferred
               raw_output: false
+            field_person_skills:
+              alias: skills
+              raw_output: false
       display_description: ''
       pager:
         type: none
@@ -2068,6 +2137,7 @@ display:
         - 'config:field.storage.user.field_person_namefirst'
         - 'config:field.storage.user.field_person_namelast'
         - 'config:field.storage.user.field_person_office'
+        - 'config:field.storage.user.field_person_skills'
         - 'config:field.storage.user.field_twitter'
         - 'config:field.storage.user.user_picture'
   rest_export_2:
@@ -2195,6 +2265,21 @@ display:
             field_linkedin_1:
               alias: linkedinTitle
               raw_output: false
+            langcode:
+              alias: langcode
+              raw_output: false
+            default_langcode:
+              alias: langcode_default
+              raw_output: false
+            content_translation_source:
+              alias: langcode_source
+              raw_output: false
+            preferred_langcode:
+              alias: langcode_user_preferred
+              raw_output: false
+            field_person_skills:
+              alias: skills
+              raw_output: false
       filters:
         status:
           value: true
@@ -2309,5 +2394,6 @@ display:
         - 'config:field.storage.user.field_person_namefirst'
         - 'config:field.storage.user.field_person_namelast'
         - 'config:field.storage.user.field_person_office'
+        - 'config:field.storage.user.field_person_skills'
         - 'config:field.storage.user.field_twitter'
         - 'config:field.storage.user.user_picture'


### PR DESCRIPTION
First commit on #53 - adds Paragraphs for skills (taxonomy terms) and levels (text list) on user accounts.

Adds to /api/team(/{uid}) endpoint, but ***at the moment*** only formatted as rendered HTML (default formatter is rendered entity)