### PR TITLE
Added multiple fields what needed for wunder-sites users

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
     "require": {
         "composer/installers": "^1.0.20",
         "cweagans/composer-patches": "~1.0",
-        "drupal/core": "8.0.*",
-        "drush/drush": "dev-master",
+        "drupal/core": "8.1.9",
+        "drush/drush": "8.*",
         "drupal/console": "~0.10",
         "drupal/image_raw_formatter": "dev-master",
         "drupal/field_group": "8.1.0-rc4",

--- a/config/staging/core.entity_form_display.user.user.default.yml
+++ b/config/staging/core.entity_form_display.user.user.default.yml
@@ -3,10 +3,14 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.user.user.field_background_image
     - field.field.user.user.field_biography
     - field.field.user.user.field_drupal_org_profile
+    - field.field.user.user.field_facebook_account
     - field.field.user.user.field_github
+    - field.field.user.user.field_instagram_account
     - field.field.user.user.field_linkedin
+    - field.field.user.user.field_login_mail
     - field.field.user.user.field_person_email
     - field.field.user.user.field_person_jobtitle
     - field.field.user.user.field_person_namefirst
@@ -15,13 +19,21 @@ dependencies:
     - field.field.user.user.field_person_skills
     - field.field.user.user.field_person_status
     - field.field.user.user.field_persongender
+    - field.field.user.user.field_picture_hover
+    - field.field.user.user.field_telephone
     - field.field.user.user.field_twitter
+    - field.field.user.user.field_user_weight
+    - field.field.user.user.field_video_background
+    - field.field.user.user.field_xing_account
     - field.field.user.user.user_picture
+    - image.style.medium
   module:
     - field_group
+    - file
     - image
     - link
     - paragraphs
+    - telephone
     - text
     - user
 third_party_settings:
@@ -54,6 +66,13 @@ content:
     weight: 9
     settings: {  }
     third_party_settings: {  }
+  field_background_image:
+    weight: 21
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
   field_biography:
     weight: 11
     settings:
@@ -68,8 +87,22 @@ content:
       placeholder_title: ''
     third_party_settings: {  }
     type: link_default
+  field_facebook_account:
+    weight: 22
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
   field_github:
     weight: 15
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+  field_instagram_account:
+    weight: 23
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -82,10 +115,18 @@ content:
       placeholder_title: ''
     third_party_settings: {  }
     type: link_default
+  field_login_mail:
+    weight: 20
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
   field_person_email:
     weight: 6
     settings:
       placeholder: ''
+      size: 60
     third_party_settings: {  }
     type: email_default
   field_person_jobtitle:
@@ -132,8 +173,40 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
+  field_picture_hover:
+    weight: 24
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
+  field_telephone:
+    weight: 25
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+    type: telephone_default
   field_twitter:
     weight: 16
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+  field_user_weight:
+    weight: 27
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+    type: number
+  field_video_background:
+    weight: 26
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
+    type: file_generic
+  field_xing_account:
+    weight: 28
     settings:
       placeholder_url: ''
       placeholder_title: ''

--- a/config/staging/core.entity_view_display.user.user.compact.yml
+++ b/config/staging/core.entity_view_display.user.user.compact.yml
@@ -13,9 +13,12 @@ dependencies:
     - field.field.user.user.field_person_namefirst
     - field.field.user.user.field_person_namelast
     - field.field.user.user.field_person_office
+    - field.field.user.user.field_person_skills
+    - field.field.user.user.field_person_status
     - field.field.user.user.field_persongender
     - field.field.user.user.field_twitter
     - field.field.user.user.user_picture
+    - image.style.thumbnail
   module:
     - image
     - user
@@ -42,6 +45,8 @@ hidden:
   field_person_namefirst: true
   field_person_namelast: true
   field_person_office: true
+  field_person_skills: true
+  field_person_status: true
   field_persongender: true
   field_twitter: true
   member_for: true

--- a/config/staging/core.entity_view_display.user.user.default.yml
+++ b/config/staging/core.entity_view_display.user.user.default.yml
@@ -3,10 +3,14 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.user.user.field_background_image
     - field.field.user.user.field_biography
     - field.field.user.user.field_drupal_org_profile
+    - field.field.user.user.field_facebook_account
     - field.field.user.user.field_github
+    - field.field.user.user.field_instagram_account
     - field.field.user.user.field_linkedin
+    - field.field.user.user.field_login_mail
     - field.field.user.user.field_person_email
     - field.field.user.user.field_person_jobtitle
     - field.field.user.user.field_person_namefirst
@@ -15,10 +19,17 @@ dependencies:
     - field.field.user.user.field_person_skills
     - field.field.user.user.field_person_status
     - field.field.user.user.field_persongender
+    - field.field.user.user.field_picture_hover
+    - field.field.user.user.field_telephone
     - field.field.user.user.field_twitter
+    - field.field.user.user.field_user_weight
+    - field.field.user.user.field_video_background
+    - field.field.user.user.field_xing_account
     - field.field.user.user.user_picture
+    - image.style.thumbnail
   module:
     - entity_reference_revisions
+    - file
     - image
     - link
     - options
@@ -29,6 +40,14 @@ targetEntityType: user
 bundle: user
 mode: default
 content:
+  field_background_image:
+    weight: 14
+    label: above
+    settings:
+      image_style: ''
+      image_link: ''
+    third_party_settings: {  }
+    type: image
   field_biography:
     weight: 6
     label: above
@@ -37,6 +56,17 @@ content:
     type: text_default
   field_drupal_org_profile:
     weight: 7
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+  field_facebook_account:
+    weight: 15
     label: above
     settings:
       trim_length: 80
@@ -57,6 +87,17 @@ content:
       target: ''
     third_party_settings: {  }
     type: link
+  field_instagram_account:
+    weight: 16
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
   field_linkedin:
     weight: 10
     label: above
@@ -68,6 +109,13 @@ content:
       target: ''
     third_party_settings: {  }
     type: link
+  field_login_mail:
+    weight: 13
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
   field_person_skills:
     type: entity_reference_revisions_entity_view
     weight: 11
@@ -82,8 +130,49 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: list_default
+  field_picture_hover:
+    weight: 17
+    label: above
+    settings:
+      image_style: ''
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+  field_telephone:
+    weight: 18
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
   field_twitter:
     weight: 9
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+  field_user_weight:
+    weight: 20
+    label: above
+    settings:
+      thousand_separator: ''
+      decimal_separator: .
+      scale: 2
+      prefix_suffix: true
+    third_party_settings: {  }
+    type: number_decimal
+  field_video_background:
+    weight: 19
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: file_default
+  field_xing_account:
+    weight: 21
     label: above
     settings:
       trim_length: 80

--- a/config/staging/core.extension.yml
+++ b/config/staging/core.extension.yml
@@ -36,6 +36,7 @@ module:
   serialization: 0
   system: 0
   taxonomy: 0
+  telephone: 0
   text: 0
   toolbar: 0
   update: 0

--- a/config/staging/field.field.user.user.field_background_image.yml
+++ b/config/staging/field.field.user.user.field_background_image.yml
@@ -1,0 +1,38 @@
+uuid: 03cddce2-9108-4cd8-bf53-5bc320a5c830
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_background_image
+  module:
+    - image
+    - user
+id: user.user.field_background_image
+field_name: field_background_image
+entity_type: user
+bundle: user
+label: 'Background Image'
+description: 'This image will appear as a background in the user page.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: ''
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: false
+  alt_field_required: false
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/config/staging/field.field.user.user.field_facebook_account.yml
+++ b/config/staging/field.field.user.user.field_facebook_account.yml
@@ -1,0 +1,23 @@
+uuid: 6ccd2df8-d51f-43f1-9610-28fba150cada
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_facebook_account
+  module:
+    - link
+    - user
+id: user.user.field_facebook_account
+field_name: field_facebook_account
+entity_type: user
+bundle: user
+label: 'Facebook Account'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 16
+  title: 0
+field_type: link

--- a/config/staging/field.field.user.user.field_instagram_account.yml
+++ b/config/staging/field.field.user.user.field_instagram_account.yml
@@ -1,0 +1,23 @@
+uuid: 6bfad382-cf63-4bd3-aaef-8757afeb136c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_instagram_account
+  module:
+    - link
+    - user
+id: user.user.field_instagram_account
+field_name: field_instagram_account
+entity_type: user
+bundle: user
+label: 'Instagram account'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 16
+  title: 0
+field_type: link

--- a/config/staging/field.field.user.user.field_login_mail.yml
+++ b/config/staging/field.field.user.user.field_login_mail.yml
@@ -1,0 +1,22 @@
+uuid: 8846cc7a-e3c0-4461-be7b-f16feb3e4ed6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_login_mail
+  module:
+    - user
+id: user.user.field_login_mail
+field_name: field_login_mail
+entity_type: user
+bundle: user
+label: 'Login mail'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: e-mail@wunderkraut.com
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/staging/field.field.user.user.field_picture_hover.yml
+++ b/config/staging/field.field.user.user.field_picture_hover.yml
@@ -1,0 +1,38 @@
+uuid: 663a65c1-94f7-4452-a4e5-fd883cd07146
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_picture_hover
+  module:
+    - image
+    - user
+id: user.user.field_picture_hover
+field_name: field_picture_hover
+entity_type: user
+bundle: user
+label: 'Picture hover'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: ''
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: false
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/config/staging/field.field.user.user.field_telephone.yml
+++ b/config/staging/field.field.user.user.field_telephone.yml
@@ -1,0 +1,21 @@
+uuid: 94bf9b42-b836-42fe-8d0a-8c319938a9a3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_telephone
+  module:
+    - telephone
+    - user
+id: user.user.field_telephone
+field_name: field_telephone
+entity_type: user
+bundle: user
+label: Telephone
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: telephone

--- a/config/staging/field.field.user.user.field_user_weight.yml
+++ b/config/staging/field.field.user.user.field_user_weight.yml
@@ -1,0 +1,24 @@
+uuid: b1651bc1-8af6-479e-bf7f-147227e8ea9a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_user_weight
+  module:
+    - user
+id: user.user.field_user_weight
+field_name: field_user_weight
+entity_type: user
+bundle: user
+label: Weight
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: decimal

--- a/config/staging/field.field.user.user.field_video_background.yml
+++ b/config/staging/field.field.user.user.field_video_background.yml
@@ -1,0 +1,27 @@
+uuid: e845386a-fcea-4885-a452-6b392b205f71
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_video_background
+  module:
+    - file
+    - user
+id: user.user.field_video_background
+field_name: field_video_background
+entity_type: user
+bundle: user
+label: 'Video background'
+description: "First field is for <b>.mp4</b>, Second field for <b>.webm</b>. Upload a <b>background image</b> above for fallback in devices and overlay for video buffering.\r\n"
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: ''
+  file_extensions: 'mp4 webm'
+  max_filesize: ''
+  description_field: false
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: file

--- a/config/staging/field.field.user.user.field_xing_account.yml
+++ b/config/staging/field.field.user.user.field_xing_account.yml
@@ -1,0 +1,23 @@
+uuid: a975866e-6a04-4c99-891b-c10a925272e7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_xing_account
+  module:
+    - link
+    - user
+id: user.user.field_xing_account
+field_name: field_xing_account
+entity_type: user
+bundle: user
+label: 'Xing account'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 16
+  title: 0
+field_type: link

--- a/config/staging/field.storage.user.field_background_image.yml
+++ b/config/staging/field.storage.user.field_background_image.yml
@@ -1,0 +1,30 @@
+uuid: 96fb5aed-426c-4da6-a1c1-81a4acad3bd9
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - user
+id: user.field_background_image
+field_name: field_background_image
+entity_type: user
+type: image
+settings:
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/staging/field.storage.user.field_facebook_account.yml
+++ b/config/staging/field.storage.user.field_facebook_account.yml
@@ -1,0 +1,19 @@
+uuid: ccf894a2-e7a5-4be5-8261-6c457705c412
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - user
+id: user.field_facebook_account
+field_name: field_facebook_account
+entity_type: user
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/staging/field.storage.user.field_instagram_account.yml
+++ b/config/staging/field.storage.user.field_instagram_account.yml
@@ -1,0 +1,19 @@
+uuid: a8d0bdb4-0551-43ef-879d-0f9c93ca0a75
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - user
+id: user.field_instagram_account
+field_name: field_instagram_account
+entity_type: user
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/staging/field.storage.user.field_login_mail.yml
+++ b/config/staging/field.storage.user.field_login_mail.yml
@@ -1,16 +1,17 @@
-uuid: 67dced12-4aba-49d3-939b-c3102d1c324a
+uuid: d0b9047b-4754-4f0f-85e3-fa7eb42489ea
 langcode: en
 status: true
 dependencies:
   module:
-    - taxonomy
     - user
-id: user.field_person_jobtitle
-field_name: field_person_jobtitle
+id: user.field_login_mail
+field_name: field_login_mail
 entity_type: user
-type: entity_reference
+type: string
 settings:
-  target_type: taxonomy_term
+  max_length: 100
+  is_ascii: false
+  case_sensitive: false
 module: core
 locked: false
 cardinality: 1

--- a/config/staging/field.storage.user.field_person_office.yml
+++ b/config/staging/field.storage.user.field_person_office.yml
@@ -13,7 +13,7 @@ settings:
   target_type: taxonomy_term
 module: core
 locked: false
-cardinality: -1
+cardinality: 1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/config/staging/field.storage.user.field_picture_hover.yml
+++ b/config/staging/field.storage.user.field_picture_hover.yml
@@ -1,0 +1,30 @@
+uuid: 337c395e-ff3b-4680-9e22-1194f712f816
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - user
+id: user.field_picture_hover
+field_name: field_picture_hover
+entity_type: user
+type: image
+settings:
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/staging/field.storage.user.field_telephone.yml
+++ b/config/staging/field.storage.user.field_telephone.yml
@@ -1,0 +1,19 @@
+uuid: 9f7e737b-26b2-4c99-bc6f-a967c2917a26
+langcode: en
+status: true
+dependencies:
+  module:
+    - telephone
+    - user
+id: user.field_telephone
+field_name: field_telephone
+entity_type: user
+type: telephone
+settings: {  }
+module: telephone
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/staging/field.storage.user.field_user_weight.yml
+++ b/config/staging/field.storage.user.field_user_weight.yml
@@ -1,16 +1,16 @@
-uuid: 67dced12-4aba-49d3-939b-c3102d1c324a
+uuid: 9de1d31f-d621-4dab-a083-3724954d5389
 langcode: en
 status: true
 dependencies:
   module:
-    - taxonomy
     - user
-id: user.field_person_jobtitle
-field_name: field_person_jobtitle
+id: user.field_user_weight
+field_name: field_user_weight
 entity_type: user
-type: entity_reference
+type: decimal
 settings:
-  target_type: taxonomy_term
+  precision: 10
+  scale: 2
 module: core
 locked: false
 cardinality: 1

--- a/config/staging/field.storage.user.field_video_background.yml
+++ b/config/staging/field.storage.user.field_video_background.yml
@@ -1,0 +1,23 @@
+uuid: af617279-e8d8-4712-9225-1ca49efca7db
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - user
+id: user.field_video_background
+field_name: field_video_background
+entity_type: user
+type: file
+settings:
+  display_field: false
+  display_default: false
+  uri_scheme: public
+  target_type: file
+module: file
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/staging/field.storage.user.field_xing_account.yml
+++ b/config/staging/field.storage.user.field_xing_account.yml
@@ -1,0 +1,19 @@
+uuid: 33888127-b986-4515-b0d4-3b9bf0ab807c
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - user
+id: user.field_xing_account
+field_name: field_xing_account
+entity_type: user
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/staging/views.view.team_listing.yml
+++ b/config/staging/views.view.team_listing.yml
@@ -5,22 +5,32 @@ dependencies:
   config:
     - field.storage.taxonomy_term.field_company
     - field.storage.taxonomy_term.field_office_country
+    - field.storage.user.field_background_image
     - field.storage.user.field_biography
     - field.storage.user.field_drupal_org_profile
+    - field.storage.user.field_facebook_account
     - field.storage.user.field_github
+    - field.storage.user.field_instagram_account
     - field.storage.user.field_linkedin
+    - field.storage.user.field_login_mail
     - field.storage.user.field_person_jobtitle
     - field.storage.user.field_person_namefirst
     - field.storage.user.field_person_namelast
     - field.storage.user.field_person_office
     - field.storage.user.field_person_skills
     - field.storage.user.field_person_status
+    - field.storage.user.field_picture_hover
+    - field.storage.user.field_telephone
     - field.storage.user.field_twitter
+    - field.storage.user.field_user_weight
+    - field.storage.user.field_video_background
+    - field.storage.user.field_xing_account
     - field.storage.user.user_picture
     - taxonomy.vocabulary.country
     - user.role.employee
   module:
     - entity_reference_revisions
+    - file
     - image_raw_formatter
     - link
     - options
@@ -93,10 +103,13 @@ display:
       style:
         type: default
         options:
-          grouping: {  }
+          grouping:
+            -
+              field: uid
+              rendered: true
+              rendered_strip: false
           row_class: ''
           default_row_class: true
-          uses_fields: false
       row:
         type: fields
         options:
@@ -105,6 +118,71 @@ display:
           hide_empty: false
           default_field_elements: true
       fields:
+        uuid:
+          id: uuid
+          table: users
+          field: uuid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: user
+          entity_field: uuid
+          plugin_id: field
         uid:
           id: uid
           table: users_field_data
@@ -170,6 +248,135 @@ display:
           field_api_classes: false
           entity_type: user
           entity_field: uid
+          plugin_id: field
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: user
+          entity_field: name
+          plugin_id: field
+        mail:
+          id: mail
+          table: users_field_data
+          field: mail
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: basic_string
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: user
+          entity_field: mail
           plugin_id: field
         field_person_namefirst:
           id: field_person_namefirst
@@ -1918,6 +2125,587 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
+        field_login_mail:
+          id: field_login_mail
+          table: user__field_login_mail
+          field: field_login_mail
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_background_image:
+          id: field_background_image
+          table: user__field_background_image
+          field: field_background_image
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: image_raw_formatter
+          settings:
+            image_style: ''
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_facebook_account:
+          id: field_facebook_account
+          table: user__field_facebook_account
+          field: field_facebook_account
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: '{{ field_facebook_account__uri }}'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: uri
+          type: link_separate
+          settings:
+            trim_length: 80
+            url_only: false
+            url_plain: false
+            rel: '0'
+            target: '0'
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_instagram_account:
+          id: field_instagram_account
+          table: user__field_instagram_account
+          field: field_instagram_account
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: '{{ field_instagram_account__uri }}'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: uri
+          type: link
+          settings:
+            trim_length: 80
+            url_only: false
+            url_plain: false
+            rel: '0'
+            target: '0'
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_picture_hover:
+          id: field_picture_hover
+          table: user__field_picture_hover
+          field: field_picture_hover
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: image_raw_formatter
+          settings:
+            image_style: ''
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_telephone:
+          id: field_telephone
+          table: user__field_telephone
+          field: field_telephone
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_video_background:
+          id: field_video_background
+          table: user__field_video_background
+          field: field_video_background
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: file_url_plain
+          settings: {  }
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_user_weight:
+          id: field_user_weight
+          table: user__field_user_weight
+          field: field_user_weight
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_decimal
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+            decimal_separator: .
+            scale: 2
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_xing_account:
+          id: field_xing_account
+          table: user__field_xing_account
+          field: field_xing_account
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: '{{ field_xing_account__uri }} '
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: uri
+          type: link_separate
+          settings:
+            trim_length: 80
+            url_only: false
+            url_plain: false
+            rel: '0'
+            target: '0'
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
       filters:
         status:
           value: true
@@ -2244,17 +3032,26 @@ display:
       tags:
         - 'config:field.storage.taxonomy_term.field_company'
         - 'config:field.storage.taxonomy_term.field_office_country'
+        - 'config:field.storage.user.field_background_image'
         - 'config:field.storage.user.field_biography'
         - 'config:field.storage.user.field_drupal_org_profile'
+        - 'config:field.storage.user.field_facebook_account'
         - 'config:field.storage.user.field_github'
+        - 'config:field.storage.user.field_instagram_account'
         - 'config:field.storage.user.field_linkedin'
+        - 'config:field.storage.user.field_login_mail'
         - 'config:field.storage.user.field_person_jobtitle'
         - 'config:field.storage.user.field_person_namefirst'
         - 'config:field.storage.user.field_person_namelast'
         - 'config:field.storage.user.field_person_office'
         - 'config:field.storage.user.field_person_skills'
         - 'config:field.storage.user.field_person_status'
+        - 'config:field.storage.user.field_picture_hover'
+        - 'config:field.storage.user.field_telephone'
         - 'config:field.storage.user.field_twitter'
+        - 'config:field.storage.user.field_user_weight'
+        - 'config:field.storage.user.field_video_background'
+        - 'config:field.storage.user.field_xing_account'
         - 'config:field.storage.user.user_picture'
   rest_export_1:
     display_plugin: rest_export
@@ -2357,6 +3154,16 @@ display:
         type: none
         options:
           offset: 0
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      defaults:
+        query: false
     cache_metadata:
       max-age: -1
       contexts:
@@ -2369,17 +3176,26 @@ display:
       tags:
         - 'config:field.storage.taxonomy_term.field_company'
         - 'config:field.storage.taxonomy_term.field_office_country'
+        - 'config:field.storage.user.field_background_image'
         - 'config:field.storage.user.field_biography'
         - 'config:field.storage.user.field_drupal_org_profile'
+        - 'config:field.storage.user.field_facebook_account'
         - 'config:field.storage.user.field_github'
+        - 'config:field.storage.user.field_instagram_account'
         - 'config:field.storage.user.field_linkedin'
+        - 'config:field.storage.user.field_login_mail'
         - 'config:field.storage.user.field_person_jobtitle'
         - 'config:field.storage.user.field_person_namefirst'
         - 'config:field.storage.user.field_person_namelast'
         - 'config:field.storage.user.field_person_office'
         - 'config:field.storage.user.field_person_skills'
         - 'config:field.storage.user.field_person_status'
+        - 'config:field.storage.user.field_picture_hover'
+        - 'config:field.storage.user.field_telephone'
         - 'config:field.storage.user.field_twitter'
+        - 'config:field.storage.user.field_user_weight'
+        - 'config:field.storage.user.field_video_background'
+        - 'config:field.storage.user.field_xing_account'
         - 'config:field.storage.user.user_picture'
   rest_export_2:
     display_plugin: rest_export
@@ -2426,7 +3242,7 @@ display:
             operation: view
             multiple: 0
             access: false
-            restrict_roles: 0
+            restrict_roles: false
             roles: {  }
           break_phrase: false
           not: false
@@ -2636,15 +3452,24 @@ display:
       tags:
         - 'config:field.storage.taxonomy_term.field_company'
         - 'config:field.storage.taxonomy_term.field_office_country'
+        - 'config:field.storage.user.field_background_image'
         - 'config:field.storage.user.field_biography'
         - 'config:field.storage.user.field_drupal_org_profile'
+        - 'config:field.storage.user.field_facebook_account'
         - 'config:field.storage.user.field_github'
+        - 'config:field.storage.user.field_instagram_account'
         - 'config:field.storage.user.field_linkedin'
+        - 'config:field.storage.user.field_login_mail'
         - 'config:field.storage.user.field_person_jobtitle'
         - 'config:field.storage.user.field_person_namefirst'
         - 'config:field.storage.user.field_person_namelast'
         - 'config:field.storage.user.field_person_office'
         - 'config:field.storage.user.field_person_skills'
         - 'config:field.storage.user.field_person_status'
+        - 'config:field.storage.user.field_picture_hover'
+        - 'config:field.storage.user.field_telephone'
         - 'config:field.storage.user.field_twitter'
+        - 'config:field.storage.user.field_user_weight'
+        - 'config:field.storage.user.field_video_background'
+        - 'config:field.storage.user.field_xing_account'
         - 'config:field.storage.user.user_picture'

--- a/web/profiles/wunderhub/modules/wkhub_person/wkhub_person.module
+++ b/web/profiles/wunderhub/modules/wkhub_person/wkhub_person.module
@@ -1,0 +1,23 @@
+<?php
+
+use Drupal\Core\Form\FormStateInterface;
+
+/*
+ * Implements hook_form_FORM_ID_alter
+ */
+function wkhub_person_form_user_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+
+/* Hide field_login_mail from form. This field is used to allow use user mail values
+ * under api/team, because by default mail value isn't visible for anonymous users.
+ */
+  $form['field_login_mail']['#access'] = FALSE;
+  //get all users
+  $users = \Drupal::entityQuery('user')->execute();
+  $users = \Drupal\user\Entity\User::loadMultiple($users);
+  //setting email for each user and saving it.
+  foreach ($users as $user) {
+    $user_mail = $user->get('mail')->value;
+    $user->set('field_login_mail', $user_mail);
+    $user->save();
+  }
+}


### PR DESCRIPTION
Added fields for user:
- Background image
- Picture hover
- Video background
- Facebook account
- Instagram account
- Xing account
- Login mail (since user mail is visible just for admins, wunder-sites wont see it. Need additional field for that. More bellow*)
- Telephone
- User weight

For _person_jobtitle_ and _office_ field cardinality is limited to `1` to avoid multiple job titles and offices per user. 

Changed Drupal core version to 8.1.9.

*Created _wkhub_person.module_ file with _hook_form_FORM_ID_alter_. It reuse user mail and saves in our custom _login_mail_ field, because user mail isn't visible for anonymous users. This also hide field to avoid user manually set the value.

To make sure everything is ok, run `composer update` and import config by `drush cim`. After that, you should be able to edit user form with new fields. Also check if under `/api/team` shows all new fields. 
